### PR TITLE
add within-field delimiter

### DIFF
--- a/marc2csv.py
+++ b/marc2csv.py
@@ -7,6 +7,8 @@ import sys
 from pymarc import MARCReader
 
 filepath = 'data.mrc'
+infield_delim = ' | '
+
 if len(sys.argv) > 1:
     filepath = sys.argv[1]
 
@@ -21,10 +23,13 @@ marc_tags = []
 
 for marc_record in reader:
     csv_record = {}
-    for marc_field in marc_record.fields:
+    for marc_field in marc_record.fields: 
         if marc_field.tag not in marc_tags:
             marc_tags.append(marc_field.tag)
-        csv_record[marc_field.tag] = marc_field.value()
+        if not csv_record.get(marc_field.tag):
+            csv_record[marc_field.tag] = marc_field.value()
+        else:
+            csv_record[marc_field.tag] += infield_delim + str(marc_field.value())
     csv_records.append(csv_record)
 
 marc_tags.sort()


### PR DESCRIPTION
Thanks for this code, which saved me a lot of time figuring out how to use pymarc for a straightforward extraction. I realized after using it that some values were missing, and it seems to be caused by overwriting in line 27 when the same MARC tag is used more than once for a given record. Here's a proposed patch.

Details:
Allow for multiple instances of the same marc_field.tag within the same record, to avoid overwriting and data loss. Append new values to existing ones with a delimiting character.